### PR TITLE
Added guard clause to setter

### DIFF
--- a/src/js/storage/storage.js
+++ b/src/js/storage/storage.js
@@ -19,8 +19,10 @@ export class Store {
   }
 
   set state(state) {
-    this.storage.setItem(this.key, JSON.stringify(state));
-  }
+    if (state) {
+      this.storage.setItem(this.key, JSON.stringify(state));
+     }
+   }
 
   clear() {
     this.storage.removeItem(this.key);


### PR DESCRIPTION
## Changelog
Added guard clause to setter.

#### Comments
In my findings the ``setter`` will run no matter what you pass as parameters in the constructor. For clearing the ``key/value`` pairing, it doesn't matter that it gets manipulated, as it gets cleared anyhow, but for extracting data from local or session storage it will manipulate any called ``key's`` ``value`` to undefined. 

I realize this is code came from Oliver,  so it's not impossible that I'm simply using it incorrectly, which is why I would appreciate if you could verify or disprove my findings. I've provided some basic test code that runs through the scope of how we would use this ``class``.

#### Test code to validate
Run with and without clause.

```js
const token = 'Some gibberish';
// Storing key/value with setter
new Store('token', token);

// Getting value with getter
const load = new Store('token').state;
console.log(load);

// Clearing data with clear()
// new Store('token').clear();
```