### PR TITLE
Includes a bg colour to prevent contrast issues

### DIFF
--- a/src/scss/custom/_clientApplication.scss
+++ b/src/scss/custom/_clientApplication.scss
@@ -9,6 +9,7 @@ Version: 1.0.0
 
 //SECTION 1
 .section1 {
+  background-color: $theme-Dark;
   background-image: url(https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80);
   background-position: center;
   background-repeat: no-repeat;


### PR DESCRIPTION
Pretty straightforward, just adds the $theme-dark colour to the banner background in case the image breaks.