### PR TITLE
Remove duplicated closing tag from index.html

### DIFF
--- a/pages/TBD/apply/index.html
+++ b/pages/TBD/apply/index.html
@@ -13,7 +13,6 @@
     <!-- X-on top of the form -->
     <script src="https://kit.fontawesome.com/7894e946c2.js" crossorigin="anonymous"></script>
   </head>
-  </head>
   <body id="applyPage">
     <header></header>
     <main class="bg-theme-grey">


### PR DESCRIPTION
Remove an extra closing tag for the head of index.html that creates an error when trying to look at the page