### PR TITLE
tidy opp head for all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,14 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Description -->
     <meta name="author" content="Noroff FED students" />
     <meta name="team" content=" FE-application  " />
     <title></title>
+    <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />
-    <script src="./index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="homePage">
     <header></header>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Description -->
-    <meta name="author" content="Noroff FED students" />
-    <meta name="team" content=" FE-application  " />
+    <meta name="description" content="" />
     <title></title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />

--- a/pages/TBD/apply/index.html
+++ b/pages/TBD/apply/index.html
@@ -4,14 +4,16 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Description -->
     <meta name="description" content="Applicants cover letter form." />
     <meta name="author" content="@ImBenni" />
     <meta name="team" content="Application" />
     <title>Application Form</title>
+    <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet">
-    <script src="/index.js" defer type="module"></script>
-    <!-- X-on top of the form -->
-    <script src="https://kit.fontawesome.com/7894e946c2.js" crossorigin="anonymous"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
+    <script src="https://kit.fontawesome.com/7894e946c2.js" crossorigin="anonymous"></script> <!-- X-on top of the form -->
   </head>
   <body id="applyPage">
     <header></header>
@@ -75,7 +77,5 @@
       </section>
     </main>
     <footer></footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/pages/TBD/apply/index.html
+++ b/pages/TBD/apply/index.html
@@ -6,8 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Description -->
     <meta name="description" content="Applicants cover letter form." />
-    <meta name="author" content="@ImBenni" />
-    <meta name="team" content="Application" />
     <title>Application Form</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet">

--- a/pages/TBD/client/application/index.html
+++ b/pages/TBD/client/application/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Description -->
     <meta name="description" content="Companies view of the applicants submitted application form." />
-    <meta name="author" content=" AUGUST_WAHLBERG " />
     <title>Client - View Application</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />

--- a/pages/TBD/client/application/index.html
+++ b/pages/TBD/client/application/index.html
@@ -4,12 +4,14 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="author" content=" AUGUST_WAHLBERG " />
     <!-- Description -->
     <meta name="description" content="Companies view of the applicants submitted application form." />
+    <meta name="author" content=" AUGUST_WAHLBERG " />
     <title>Client - View Application</title>
+    <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />
-    <script src="/index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="singleApplicationPage">
     <header></header>
@@ -72,6 +74,5 @@
       <!-- Card wrapper ends-->
     </main>
     <footer></footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/pages/TBD/index.html
+++ b/pages/TBD/index.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Description -->
     <meta name="description" content="" />
     <title>Offer Form</title>
+    <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />
-    <script src="/index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="offerPage" class="d-flex flex-column min-vh-100 gap-4">
     <header></header>
@@ -61,6 +64,5 @@
       </div>
     </main>
     <footer></footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/pages/TBD/index.html
+++ b/pages/TBD/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Description -->
-    <meta name="description" content="" />
+    <meta name="description" content="page for creating an offer" />
     <title>Offer Form</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />

--- a/pages/TBD/listings.html
+++ b/pages/TBD/listings.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title></title>
+    <!-- Description -->
     <title>Noroff Jobs</title>
+    <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />
-    <script src="/index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="listingsPage">
     <header></header>
@@ -98,6 +100,5 @@
       </div>
     </main>
     <footer></footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/pages/TBD/listings.html
+++ b/pages/TBD/listings.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Description -->
+    <meta name="description" content="this page contains a list of awaitable job opportunities" />
     <title>Noroff Jobs</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />

--- a/pages/listings/index.html
+++ b/pages/listings/index.html
@@ -9,7 +9,8 @@
     <title>Noroff Jobs</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet">
-    <script src="/index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="listing">
     <!--Header is created trough JS script-->
@@ -118,7 +119,5 @@
     </main>
     <!--Footer is created trough JS script-->
     <footer></footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/pages/user/index.html
+++ b/pages/user/index.html
@@ -19,13 +19,14 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Dev -->
+    <!-- Description -->
     <meta name="author" content="@Menubrea" />
     <meta name="team" content="User" />
     <title>Noroff Jobs</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />
-    <script src="/index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="profilePage" class="bg-theme-grey">
     <header>
@@ -250,6 +251,5 @@
     <footer>
       <!-- Footer -->
     </footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/pages/user/index.html
+++ b/pages/user/index.html
@@ -20,8 +20,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Description -->
-    <meta name="author" content="@Menubrea" />
-    <meta name="team" content="User" />
+    <meta name="description" content="the users profile page" />
     <title>Noroff Jobs</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -4,12 +4,14 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/css/index.css" />
+    <!-- Description -->
     <meta name="author" content="Noroff FED Students" />
     <meta name="team" content="FE-application" />
     <title>Privacy Policy</title>
+    <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />
-    <script src="./index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="privacyPolicy">
     <header></header>
@@ -55,6 +57,5 @@
       <a href="/" class="btn btn-theme-secondary">Back</a>
     </main>
     <footer></footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -5,8 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Description -->
-    <meta name="author" content="Noroff FED Students" />
-    <meta name="team" content="FE-application" />
+    <meta name="description" content="this page have information on our privacy polices" />
     <title>Privacy Policy</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />

--- a/terms_of_use.html
+++ b/terms_of_use.html
@@ -5,11 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/css/index.css" />
+    <!-- Description -->
     <meta name="author" content="Noroff FED Students" />
     <meta name="team" content="FE-application" />
     <title>Terms of Use</title>
+    <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />
-    <script src="./index.js" defer type="module"></script>
+    <script defer src="./index.js" type="module"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </head>
   <body id="termsOfUse">
     <header></header>
@@ -56,6 +59,5 @@
       <a href="/" class="btn btn-theme-secondary">Back</a>
     </main>
     <footer></footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/terms_of_use.html
+++ b/terms_of_use.html
@@ -4,10 +4,8 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/css/index.css" />
     <!-- Description -->
-    <meta name="author" content="Noroff FED Students" />
-    <meta name="team" content="FE-application" />
+    <meta name="description" content="page containing the terms of use for the site" />
     <title>Terms of Use</title>
     <!-- Links and scripts -->
     <link href="/css/index.css" rel="stylesheet" />


### PR DESCRIPTION
# what has been done:
- used comments to split the head up into parts [as seen here](https://github.com/NoroffFEU/agency.noroff.dev/blob/91bede3563fa5a9cd791fb08a5467c2282e0d99d/pages/auth/register/applicant/index.html#L3-L13)
- moved the script tag for bootstrap in to the appropriate section in the head
- removed `<meta name="author" content="...">`
- removed `<meta name="team" content="...">`
- added or filed in  `<meta name="description" content="...">`
- removed duplicate` <link>` or `<script>` tags