### PR TITLE
Fixes sticky header

### DIFF
--- a/src/js/ui/header/index.js
+++ b/src/js/ui/header/index.js
@@ -8,9 +8,7 @@
  */
 export const header = () => {
   const headerElement = document.querySelector('header');
-  headerElement.classList.add('bg-theme-dark');
-  headerElement.style.position = 'sticky';
-  headerElement.style.top = '0';
+  headerElement.classList.add('bg-theme-dark', 'sticky-top');
 
   return (headerElement.innerHTML = `<div class="container-fluid px-md-5">
   <nav class="navbar navbar-expand-lg mx-0 mx-md-5 px-0 px-md-5 py-2">


### PR DESCRIPTION
Sticky header is present, then disappears and reappears when scrolling. This might be caused by setting position: sticky and top: 0px on the header element in Bootstrap instead of using a utility class.

suggested solution: set Bootstrap utility class "sticky-top" on header.