### PR TITLE
fix(remove back button): Removed back button from policy page

### DIFF
--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -15,7 +15,6 @@
   <body id="privacyPolicy">
     <header></header>
     <main class="container mt-4 mb-4">
-      <a href="/" class="btn btn-theme-secondary">Back</a>
       <div class="d-flex flex-column gap-3">
         <h1>Privacy Policy</h1>
         <p>This Privacy Policy explains how we collect, use, and disclose information that we receive through our website and mobile application (collectively, the "Service"). By using the Service, you consent to the collection, use, and disclosure of your information as described in this Privacy Policy.</p>


### PR DESCRIPTION
[agency.noroff.dev #473: The privacy page has two back buttons](https://github.com/orgs/NoroffFEU/projects/6/views/36?layout=board&pane=issue&itemId=49278880)

Removed the back button at the top of the privacy policy page. 