### PR TITLE
Fixes API path URL in getListOfListings

### DIFF
--- a/src/js/api/posts/getListOfListings.js
+++ b/src/js/api/posts/getListOfListings.js
@@ -1,12 +1,12 @@
 // Author: Emilie Herrera Thomsen
 // The Dummy json needs to be replaced with actual endpoint.
 
-import { apiPath } from '../constants.js';
+import { apiPath, listingsUrl } from '../constants.js';
 import { headers } from '../headers.js';
 import { message } from '../../utilities/message/message.js';
 
 export async function getListOfListings() {
-  const response = await fetch(apiPath, {
+  const response = await fetch(`${apiPath}${listingsUrl}`, {
     headers: headers(),
     body: JSON.stringify(),
   });


### PR DESCRIPTION
## Title
<!-- Enter your ticket number and text, and make a link to it -->
#705 Listings || Wrong API path

## Describe your changes: 
<!-- Describe what changes you did, and include screenshots if necessary -->
Changes the API path for getListOfListings function to fetch from the correct API URL

## Type of changes:
<!-- What type of changes did you make? -->
JavaScript

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
<!-- Remove the line below that you don't need -->
- No, issues encountered.
<!-- Description of the issues you run into -->

## Screenshots:
<!-- Remove the line below that you don't need -->
- No screenshots to include.
