### PR TITLE
remove non-existing deploy step

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,10 +32,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         run: npm i
-      - name: Build CSS
+      - name: Vite build
         run: npm run build
-      - name: Build Vite
-        run: npm run vite-build
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact


### PR DESCRIPTION


## Type of changes:
Deploy action tried to run npm script "vite-build". This script does not exist in package.json. 
This PR removes this deploy step, and should fix the problem with deployment.

