### PR TITLE
Logo class name is fixed

### DIFF
--- a/src/js/ui/header/index.js
+++ b/src/js/ui/header/index.js
@@ -18,7 +18,7 @@ export const header = () => {
         <a class="navbar-brand ms-5 me-0 p-0" href="/">
         <div class="d-flex gap-2">
 
-          <img src="../../../../public/assets/icons/noroff-logo.svg" class="Logo-noroff my-auto" style="width: 40px;height: 56px" />
+          <img src="../../../../public/assets/icons/noroff-logo.svg" class="logo-noroff my-auto"/>
 
           <div class="d-flex flex-column">
             <span class="company_name fs-4 fw-semibold text-white" style="height: 28px">Noroff</span>


### PR DESCRIPTION
The current class name is wrong, by using the correct class the inline styling can be removed. I will handle this issue.

Before:
<img src="https://i.imgur.com/hM7zXIv.png">

After:

<img src="https://i.imgur.com/ukm4BkX.png">
