### PR TITLE
Fixed Registration WCAG-compliant Text Issue #648

### DIFF
--- a/src/js/ui/message/displayMessage.js
+++ b/src/js/ui/message/displayMessage.js
@@ -16,7 +16,7 @@ export function displayMessage(type, message, target) {
 
   const displayError = message.replace(/\n/g, '<br>');
 
-  container.innerHTML = `<div class="alert alert-${type}">
+  container.innerHTML = `<div class="alert alert-${type} text-primary">
                          ${displayError}
                          </div>`;
 }


### PR DESCRIPTION
## Fixed Registration WCAG-compliant Text Issue #648
[Registration successful box is not WCAG-compliant #648 ](https://github.com/NoroffFEU/agency.noroff.dev/issues/648)

## Describe your changes: 
So what I changed, was the text color for the success box that appear after successfully registering a user. 

Since the color of the box was green, I decided that a blue text color would work.



| Before | After |
|--------|-------|
| ![Before 1](https://github.com/NoroffFEU/agency.noroff.dev/assets/56642911/d29792c0-d224-49e2-81a1-bf575d8e8aed) | ![After 1](https://github.com/NoroffFEU/agency.noroff.dev/assets/56642911/0efc4e5c-1c81-4db7-a69e-5805e4634f41) |
| ![Before 2](https://github.com/NoroffFEU/agency.noroff.dev/assets/56642911/0efabcee-34f1-454f-8321-761db85f6190) | ![After 2](https://github.com/NoroffFEU/agency.noroff.dev/assets/56642911/6b9b24e7-a290-4d58-8153-4763a3316566) |
| ![Before 3](https://github.com/NoroffFEU/agency.noroff.dev/assets/56642911/cef1d0af-96c5-4ec0-88d6-fcb3cf539518) | ![After 3](https://github.com/NoroffFEU/agency.noroff.dev/assets/56642911/a495f151-d80f-4312-b555-56be8d1bd0c4) |





## Additional information:
Note that the changes are only made on the applicant registration form, because the company registration form is not working at the moment.


