### PR TITLE
add stale issue bot

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -1,0 +1,26 @@
+name: Close Stale Issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # every day at midnight
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  close-stale-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale Issues
+        uses: actions/stale@v9.0.0
+        with:
+          stale-issue-message: 'This issue is being closed because it has been inactive for 30 days. Please open a new issue if you are still encountering this problem.'
+          stale-pr-message: 'This pull request is being closed because it has been inactive for 30 days. Please open a new issue if you are still encountering this problem.'
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'in-progress, bug'
+          exempt-pr-labels: 'in-progress, bug'


### PR DESCRIPTION
Adds a github workflow which marks inactive PRs as stale after 30 days and closes them after 7.