### PR TITLE
Fixes the broken nav toggler to display

### DIFF
--- a/src/js/ui/header/header.js
+++ b/src/js/ui/header/header.js
@@ -7,7 +7,7 @@ export const header = () => {
   header.classList.add('bg-theme-dark', 'fixed-top', 'align-items-center', 'shadow-lg', 'p-2');
 
   const nav = document.createElement('nav');
-  nav.classList.add('navbar', 'navbar-expand-md', 'me-lg-3', 'p-0', 'bg-theme-dark');
+  nav.classList.add('navbar', 'navbar-dark', 'navbar-expand-md', 'me-lg-3', 'p-0');
 
   const container = document.createElement('div');
   container.classList.add('container-fluid');
@@ -37,7 +37,7 @@ export const header = () => {
   logoContainer.append(img, logoText);
 
   const button = document.createElement('button');
-  button.classList.add('navbar-toggler', 'navbar-dark', 'border-0', 'ms-auto');
+  button.classList.add('navbar-toggler', 'border-0', 'ms-auto', 'p-0');
   button.setAttribute('type', 'button');
   button.setAttribute('data-bs-toggle', 'collapse');
   button.setAttribute('data-bs-target', '#navbarNavDropdown');
@@ -46,7 +46,7 @@ export const header = () => {
   button.setAttribute('aria-label', 'Toggle navigation');
 
   const span = document.createElement('span');
-  span.classList.add('navbar-toggler-icon', 'navbar-dark');
+  span.classList.add('navbar-toggler-icon');
   button.append(span);
 
   const navbarCollapse = document.createElement('div');

--- a/src/scss/custom/_hamburgerBtn.scss
+++ b/src/scss/custom/_hamburgerBtn.scss
@@ -1,75 +1,75 @@
-@import './themeColorVariables';
+// @import './themeColorVariables';
 
-.navbar-toggler-icon,
-.navbar-toggler-icon .navbar-dark {
-  background-image: none !important;
-}
+// .navbar-toggler-icon,
+// .navbar-toggler-icon .navbar-dark {
+//   // background-image: none !important;
+// }
 
-// The hamburger container. Changing height and width shouldn't affect the hamburger
-.navbar-toggler {
-  position: relative !important;
-  align-items: center !important;
-  justify-content: center !important;
-  background-color: transparent !important;
-  width: 56px !important;
-  height: 56px !important;
-}
+// // The hamburger container. Changing height and width shouldn't affect the hamburger
+// .navbar-toggler {
+//   position: relative !important;
+//   align-items: center !important;
+//   justify-content: center !important;
+//   background-color: transparent !important;
+//   width: 56px !important;
+//   height: 56px !important;
+// }
 
-// Hamburger icon when the nav is closed
-.navbar-toggler.collapsed {
-  .hamburger {
-    width: 60% !important;
-  }
+// // Hamburger icon when the nav is closed
+// .navbar-toggler.collapsed {
+//   .hamburger {
+//     width: 60% !important;
+//   }
 
-  .hamburger-top {
-    top: 25% !important;
-    transform: rotate(0deg);
-  }
+//   .hamburger-top {
+//     top: 25% !important;
+//     transform: rotate(0deg);
+//   }
 
-  .hamburger-mid {
-    opacity: 1;
-  }
+//   .hamburger-mid {
+//     opacity: 1;
+//   }
 
-  .hamburger-bottom {
-    bottom: 25% !important;
-    transform: rotate(0deg);
-  }
-}
+//   .hamburger-bottom {
+//     bottom: 25% !important;
+//     transform: rotate(0deg);
+//   }
+// }
 
-.hamburger {
-  display: flex !important;
-  position: absolute !important;
-  background-color: map-get($theme-colors, theme-new-light) !important;
-  height: 7% !important;
-  transition: 0.2s;
-}
+// .hamburger {
+//   display: flex !important;
+//   position: absolute !important;
+//   background-color: map-get($theme-colors, theme-new-light) !important;
+//   height: 7% !important;
+//   transition: 0.2s;
+// }
 
-// Hamburger as an X
-.hamburger-top,
-.hamburger-bottom {
-  width: 75%;
-}
+// // Hamburger as an X
+// .hamburger-top,
+// .hamburger-bottom {
+//   width: 75%;
+// }
 
-.hamburger-top {
-  transform: rotate(45deg);
-}
+// .hamburger-top {
+//   transform: rotate(45deg);
+// }
 
-.hamburger-mid {
-  opacity: 0;
-}
+// .hamburger-mid {
+//   opacity: 0;
+// }
 
-.hamburger-bottom {
-  transform: rotate(-45deg);
-}
+// .hamburger-bottom {
+//   transform: rotate(-45deg);
+// }
 
-@media (min-width: 767px) {
-  .navbar-toggler {
-    display: none !important;
-  }
-}
+// @media (min-width: 767px) {
+//   .navbar-toggler {
+//     display: none !important;
+//   }
+// }
 
-@media (max-width: 767px) {
-  .navbar-toggler {
-    display: flex !important;
-  }
-}
+// @media (max-width: 767px) {
+//   .navbar-toggler {
+//     display: flex !important;
+//   }
+// }

--- a/src/scss/custom/_header.scss
+++ b/src/scss/custom/_header.scss
@@ -1,3 +1,5 @@
+@import './themeColorVariables';
+
 header {
   .navbarBrand {
     img {
@@ -20,13 +22,9 @@ header {
       }
     }
   }
-  button {
-    span {
-      background-color: lightgray;
-    }
-  }
 }
 
-//Customize the hamburger menu icon -- This doesnt work as of now. Fix on the way.
-$navbar-dark-toggler-icon-bg: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#fff' stroke-linecap='square' stroke-miterlimit='10' stroke-width='3' d='M4 7h22M4 15h22M4 23h22'/></svg>");
+//Customize the hamburger menu icon
+$navbar-dark-toggler-icon-bg: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{map-get($theme-colors, theme-new-light)}' stroke-linecap='square' stroke-miterlimit='10' stroke-width='3' d='M4 7h22M4 15h22M4 23h22'/></svg>");
 $navbar-toggler-font-size: 2rem;
+$navbar-toggler-focus-width: none;


### PR DESCRIPTION
## Title
#784 

## Describe your changes: 

- Changes bootstrap classes on navigation and SCSS to display the hamburger navigation toggler.

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
- No, issues encountered.

## Screenshots:
- Yes, the screenshots are included in the table below.

| Before | After |
---------|--------
![image](https://github.com/NoroffFEU/agency.noroff.dev/assets/99018848/c0daf486-b1b6-48b1-a575-7483083caa42) 
![image](https://github.com/NoroffFEU/agency.noroff.dev/assets/99018848/e1c834fa-ba56-4833-acbc-fbcb6cda9d0a)


## Additional information:
This is a part of task #672 

## Feedback
- Yes, I want feedback.
