### PR TITLE
#672 bold element and login and register button same size

### DIFF
--- a/src/js/ui/header/checkState.js
+++ b/src/js/ui/header/checkState.js
@@ -53,7 +53,7 @@ export const checkState = () => {
     const registerLi = document.createElement('li');
     registerLi.classList.add('nav-item');
     const registerBtn = document.createElement('a');
-    registerBtn.classList.add('btn', 'btn-theme-secondary', 'text-black', 'fw-semibold');
+    registerBtn.classList.add('btn', 'btn-theme-secondary', 'text-black', 'fw-semibold','navBtnCustomWidth');
     registerBtn.href = '/pages/auth/register/applicant/';
     registerBtn.textContent = 'Register';
     registerBtn.id = 'registerUser';

--- a/src/js/ui/header/currentlyOn.js
+++ b/src/js/ui/header/currentlyOn.js
@@ -1,0 +1,6 @@
+export function boldNavElement(){
+    if(document.querySelector('[aria-current]') !== null){
+        let currentlyOn= document.querySelector('[aria-current]');
+        currentlyOn.classList.add('fw-bold')
+    }
+}

--- a/src/js/ui/header/displayLoginLogoutButton.js
+++ b/src/js/ui/header/displayLoginLogoutButton.js
@@ -38,7 +38,7 @@ export function displayLoginLogoutButton(role) {
     loginLi.classList.add('nav-item');
 
     const loginBtn = document.createElement('a');
-    loginBtn.classList.add('btn', 'btn', 'btn-outline-light', 'text-white', 'fw-semibold');
+    loginBtn.classList.add('btn', 'btn', 'btn-outline-light', 'text-white', 'fw-semibold','navBtnCustomWidth');
     loginBtn.href = '/pages/auth/login/';
     loginBtn.id = 'navItems';
     loginBtn.textContent = 'Log in';

--- a/src/js/ui/index.js
+++ b/src/js/ui/index.js
@@ -1,12 +1,14 @@
 import { header } from './header/index.js';
 import { checkState } from './header/index.js';
 import { footer } from './footer/index.js';
+import { boldNavElement } from './header/currentlyOn.js';
 //import { changeTabApperence } from './admin/tabs.js';
 
 export const displayBaseLayout = () => {
   const headerSection = header();
   if (headerSection) {
     checkState();
+    boldNavElement();
   }
   footer();
 };

--- a/src/scss/custom/_header.scss
+++ b/src/scss/custom/_header.scss
@@ -23,6 +23,9 @@ header {
     }
   }
 }
+.navBtnCustomWidth {
+  min-width: 88px;
+}
 
 //Customize the hamburger menu icon
 $navbar-dark-toggler-icon-bg: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{map-get($theme-colors, theme-new-light)}' stroke-linecap='square' stroke-miterlimit='10' stroke-width='3' d='M4 7h22M4 15h22M4 23h22'/></svg>");


### PR DESCRIPTION
## Title
#672 bold element, and login and register button same size

## Describe your changes: 
-made a custom scss class to make the login and registration button the same size
- made a small js function that uses the aria-current attribute to change the font of that nav element to bold

## Type of changes:
SCSS, bootstrap and JS changes

## Checklist before requesting a review

* [x ] I created a new branch before starting with this ticket?
* [x ] I commented the issue after finish in the Frontend Team Board?
* [ x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
- No, issues encountered.

## Screenshots:
- Yes, the screenshots are included in the table below.
the user is on home page so home page nav element is bold
![alt2](https://github.com/NoroffFEU/agency.noroff.dev/assets/54117459/20d7e47b-51ee-49dc-b869-9c18636bbc6b)
the buttons are now the same size
![same size](https://github.com/NoroffFEU/agency.noroff.dev/assets/54117459/f4c1c314-f421-4233-8506-bff143ca85e5)


