### PR TITLE
center footer in desktop sizes

### DIFF
--- a/src/scss/custom/_footer.scss
+++ b/src/scss/custom/_footer.scss
@@ -20,3 +20,13 @@ div[data-footer-col] {
     justify-content: center;
   }
 }
+
+@media only screen and (min-width: 992px) {
+  .center-desktop {
+    > div {
+      width: auto;
+      padding-left: 30px;
+      padding-right: 30px;
+    }
+  }
+}


### PR DESCRIPTION
## Title
[Center footer in desktop sizes #802](https://github.com/NoroffFEU/agency.noroff.dev/issues/802)

## Describe your changes: 
Center footer in desktop sizes, preferably 992px and above

## Type of changes:
CSS changer to center footer

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
<!-- Remove the line below that you don't need -->
- Yes, I encountered issues. (Please describe below).
The footer in desktop sizes from 992px and above is  not looking good since its not centered.

## Screenshots:
<!-- Remove the line below that you don't need -->
- No screenshots to include. Its just a simple css. See desktop footer

## Additional information:
Now that had applied new css styles, See that the footer is centered properly from 992px and above

## Feedback
<!-- Remove the line below that you don't need -->
- Yes, I want feedback.
