### PR TITLE
Fix/remove vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ dist
 
 # vscode settings folder
 .vscode
+
+#.history folder
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ dist
 
 # IntelliJ project folder
 .idea
+
+# vscode settings folder
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "liveServer.settings.port": 5501,
-  "editor.formatOnSave": false,
-}


### PR DESCRIPTION
This PR deletes the .vscode folder and adds it to .gitignore so that users can have their preferred settings enabled in vscode.
It also adds the .history folder to .gitignore.