### PR TITLE
#952 success modal will not currently open on successful editing

### DIFF
--- a/pages/listings/listing/index.html
+++ b/pages/listings/listing/index.html
@@ -151,6 +151,10 @@
                       >
                         VIEW LISTING
                       </a>
+                      <button class="d-none" id="hide-edit-modal"
+                        data-bs-dismiss="modal"
+                        data-bs-target="#editListingModal">
+                      </button>
                     </div>
                   </div>
                 </div>

--- a/src/js/api/posts/editSingleListing.js
+++ b/src/js/api/posts/editSingleListing.js
@@ -20,8 +20,8 @@ export async function editSingleListing(id, updatedData) {
 
   try {
     const accessToken = getToken('token');
-    if (!accessToken){
-      throw new Error("Access token is not available");
+    if (!accessToken) {
+      throw new Error('Access token is not available');
     }
     const newAccessToken = accessToken.replace(/^"|"$/g, '');
 
@@ -35,7 +35,11 @@ export async function editSingleListing(id, updatedData) {
 
     if (!response.ok) {
       const editResponse = await response.json();
+      alert(`Error editing listing: ${editResponse.message}`);
       throw new Error(`Error editing listing: ${editResponse.message || response.statusText}`);
+    } else {
+      document.getElementById('hide-edit-modal').click();
+      new bootstrap.Modal(document.querySelector('#success-modal')).show();
     }
 
     return response.json();

--- a/src/js/api/posts/editSingleListing.test.js
+++ b/src/js/api/posts/editSingleListing.test.js
@@ -5,9 +5,20 @@ jest.mock('../getToken.js', () => ({
   getToken: jest.fn().mockReturnValue('mocked-token'),
 }));
 
+document.getElementById = jest.fn().mockImplementation((id) => {
+  if (id === 'hide-edit-modal') {
+    return { click: jest.fn() };
+  }
+  return null;
+});
+
+window.bootstrap = { Modal: jest.fn().mockImplementation(() => ({ show: jest.fn() })) };
+
 describe('editSingleListing', () => {
   beforeEach(() => {
     fetch.mockClear();
+    document.getElementById.mockClear();
+    window.bootstrap.Modal.mockClear();
   });
 
   it('should return updated data on successful edit', async () => {
@@ -22,6 +33,8 @@ describe('editSingleListing', () => {
 
     const result = await editSingleListing(mockListingId, mockUpdatedData);
 
+    expect(document.getElementById).toHaveBeenCalledWith('hide-edit-modal');
+    expect(window.bootstrap.Modal).toHaveBeenCalled();
     expect(result).toEqual(mockApiResponse);
   });
 


### PR DESCRIPTION
## Title
success modal will not currently open on successful editing.
[#952](https://github.com/NoroffFEU/agency.noroff.dev/issues/952)

## Describe your changes: 
Added necessary code to editSingleListing.js, and for button in listing/index.html

## Type of changes:
Added code to editSingleListing.js and listing/index.html

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
- Yes, I encountered issues.
Had some problems with index.js and body id.
A new task has been created to solve this problem.

## Feedback
- Yes, I want feedback.
