### PR TITLE
Changed renderListings.js to use map - restored listings parameter

### DIFF
--- a/src/js/templates/listings/renderListings.js
+++ b/src/js/templates/listings/renderListings.js
@@ -11,17 +11,21 @@ import { getListOfListings } from '../../api/posts/getListOfListings.js';
 import { createElement } from '../CreateHtml.js';
 import { parseDate } from '../../utilities/parse/parse.js';
 
-export const renderListings = async () => {
-  const listingsContainer = document.querySelector('.listingContainer');
+let cachedListings = null;
 
+export const renderListings = async (listings) => {
+  const listingsContainer = document.querySelector('.listingContainer');
   listingsContainer.innerHTML = '';
 
-  const listings = await getListOfListings();
+  if (!listings) {
+    if(!cachedListings){
+    cachedListings = await getListOfListings();
+    }
+    listings = cachedListings;
+  }
 
-  listings.forEach((listing) => {
-    const listingCards = createListings(listing);
-    listingsContainer.append(listingCards);
-  });
+  const listingElements = listings.map(createListings);
+  listingElements.forEach(element => listingsContainer.append(element));
 };
 
 export const renderNoListings = async () => {


### PR DESCRIPTION
## Title
#961 Refine search and filter to use map()

## Describe your changes: 
Restored the listings parameter
Implemented caching and map()

## Type of changes:
I completed this task a bit differently than originally intended.

The renderListing function now checks if listings are provided as an argument, if not it proceeds to check the cache.
If cachedListings is null (indicating no cached data), the function fetches listings from the API using the getListOfListings function and stores them in cachedListings. 

When cachedListings is populated, it assigns to listings so all subsequent calls to renderListings without the listings parameter will use the cached data. 

This way, the search and filter functions that uses renderListings will use the cached array of listings instead of fetching on every keystroke.

I found this to be a more elegant sollution.

I also introduced map() to more efficiently transform the data into HTML elements. 



## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
- No, issues encountered.


## Screenshots:

- No screenshots to include.

## Additional information:
n/a

## Feedback
- Yes, I want feedback.
