### PR TITLE
Fix: Prevent duplication of skills on edit profile (applicant)

### DIFF
--- a/src/js/templates/profile/applicantProfile.js
+++ b/src/js/templates/profile/applicantProfile.js
@@ -29,6 +29,8 @@ export function applicantProfile(data) {
   applicantRole.innerText = data.role;
   companyContact.classList.add('d-none');
   const { skills } = data; // SkillsContainer
+  skillsList.innerHTML = '';
+
   if (Array.isArray(skills) && skills.length > 0) {
     skills.forEach((item) => {
       const renderSkill = document.createElement('li');

--- a/src/js/templates/profile/applicantProfile.js
+++ b/src/js/templates/profile/applicantProfile.js
@@ -19,13 +19,6 @@ export function applicantProfile(data) {
     data.avatar ||
     'https://miniforetak.no/wp-content/plugins/buddyboss-platform/bp-core/images/profile-avatar-buddyboss.png';
   profileImage.alt = (userName.innerText || 'Unknown') + 'avatar';
-  // Mariusz Rozycki as phoenix QA -
-  // I changed 'applicantRole.innerText = data.title' to 'applicantRole.innerText = data.title'
-  // to render applicantRole on 'edit website'.
-  // Then tests:
-  // 'should login successfully with the correct credentials'
-  // 'should logout successfully'
-  // from file login.cy.js are passing.
   applicantRole.innerText = data.role;
   companyContact.classList.add('d-none');
   const { skills } = data; // SkillsContainer
@@ -42,8 +35,4 @@ export function applicantProfile(data) {
   descriptionHeader.innerText = 'About me';
   profileDescription.textContent = data.about;
   editUserForm.classList.remove('d-none');
-
-  // Favorite listings section
-  // The profile view will have a container component that will display the favorite listings of the Applicant.
-  // That code goes here
 }


### PR DESCRIPTION

## Title
<!-- Enter your ticket number and text, and make a link to it -->
[#1096]. Fix: Prevent duplication of skills on edit profile (applicant) by clearing existing list before rendering
## Describe your changes: 
<!-- Describe what changes you did, and include screenshots if necessary -->
The applicantProfile function was causing skills to be duplicated each time the function was called, such as when the "Edit Profile" modal was opened and closed without saving.
- Added skillsList.innerHTML = ''; to clear the existing list before rendering skills dynamically.
- This ensures that the skills section no longer duplicates entries on repeated renders
## Type of changes:
<!-- What type of changes did you make? -->
- Bug fix (prevents duplication of skills on the profile page).
## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
<!-- Remove the line below that you don't need -->
- No, issues encountered.

## Screenshots:
<!-- Remove the line below that you don't need -->
- No screenshots to include.

## Additional information:
<!-- Fill in other information here -->

## Feedback
<!-- Remove the line below that you don't need -->
- No, I don't want feedback.
