### PR TITLE
add delayed page reload after profile edit. update jsdocs with desc.

### DIFF
--- a/src/js/api/users/editStudent.js
+++ b/src/js/api/users/editStudent.js
@@ -56,7 +56,7 @@ export async function editStudent(profile) {
 
         setTimeout(() => {
           location.replace(location.href);
-        }, 700);
+        }, 1500);
 
         return profile;
       }

--- a/src/js/api/users/editStudent.js
+++ b/src/js/api/users/editStudent.js
@@ -11,6 +11,15 @@ const action = 'users/';
  * @param {Object} profile The updated user profile data
  * @returns {Promise<Object>} A Promise that resolves with the updated user profile
  * @throws {Error} If the 'id' is missing, the API request fails, or if it returns an error status
+ *
+ * @description
+ * - Retrieves the user ID from localStorage.
+ * - Constructs the API endpoint dynamically using 'apiPath' and 'action'.
+ * - Sends an authenticated PUT request with the updated profile data.
+ * - Displays a modal on success and reloads the page after 700ms.
+ * - Attaches an event listener to close the modal on click.
+ * - Catches errors and displays an error message in '#editUserErrorContainer'.
+ *
  */
 
 export async function editStudent(profile) {
@@ -37,13 +46,17 @@ export async function editStudent(profile) {
       successMessage.close();
       successMessage.style.display = 'none';
     };
-  
+
     switch (response.status) {
       case 200: {
         successMessage.style.display = 'flex';
         successMessage.showModal();
 
         successMessage.addEventListener('click', closeModal);
+
+        setTimeout(() => {
+          location.replace(location.href);
+        }, 700);
 
         return profile;
       }


### PR DESCRIPTION
## Title
Automatically Reload Page After Successful Profile Update
[#1098](https://github.com/NoroffFEU/agency.noroff.dev/issues/1098)

## Describe your changes: 
Added a delayed page reload to the editProfile function. 

## Type of changes:
Added a timeout function to location.replace() to make the successmessage appear before reload.

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
- No, issues encountered.

## Screenshots:
- No screenshots to include.

## Additional information:
Could force an API fetch to bypass page reload, but I think a page reload is sufficient.
Resolves #1098 


## Feedback
- Yes, I want feedback.
