### PR TITLE
Update static.yml

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './'


### PR DESCRIPTION
Further updates to static.yml.
Have consulted with teacher to confirm this is the correct versions. 

The versions we used when we took over the project was deprecated 01/30/2025: https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/