### PR TITLE
1130 missing company user guide page

### DIFF
--- a/pages/footer/companyUserGuide.html
+++ b/pages/footer/companyUserGuide.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Author -->
+    <meta name="author" content="@vanya992" />
+    <meta name="team" content="nordmarka" />
+    <!-- Description -->
+    <meta name="description" content="Noroff Jobs User login page." />
+    <title>Noroff Job Agency | Company User Guide</title>
+    <!-- Links and scripts -->
+    <link
+      rel="stylesheet"
+      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+    />
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="/index.js" defer type="module"></script>
+  </head>
+  <body>
+    <header></header>
+    <main class="mb-5">
+      <section>
+        <div class="container-fluid px-0"></div>
+        <div class="container d-flex flex-column col-md-8">
+          <h1 class="mt-5">Company User Guide</h1>
+          <hr />
+          <p>
+            Welcome to the Noroff Jobs Company User Guide. This guide will help you navigate our
+            platform and effectively post job listings to connect with talented students and
+            graduates.
+          </p>
+
+          <h3>Creating an Account</h3>
+          <p>
+            To get started, register for an account using your company email. Once verified, you
+            will have access to our job posting features.
+          </p>
+
+          <h3>Posting a Job Listing</h3>
+          <p>
+            - Navigate to the "Create Listing" section.<br />
+            - Fill out the job details, including title, description, and required
+            qualifications.<br />
+            - Set an application deadline.<br />
+            - Upload any relevant media or documents.<br />
+            - Submit for review before publishing.
+          </p>
+
+          <h3>Managing Applications</h3>
+          <p>
+            Once your job listing is live, you can track and manage applications through your
+            dashboard. Shortlist candidates and communicate with them directly through the platform.
+          </p>
+
+          <h3>Company Profile Customization</h3>
+          <p>
+            Enhance your company’s visibility by updating your profile with a logo, company
+            description, and key information about your organization.
+          </p>
+
+          <h3>Need Help?</h3>
+          <p>
+            Our support team is available to assist with any technical issues or inquiries. Contact
+            us through the support page or email us at support@noroffjobs.com.
+          </p>
+        </div>
+      </section>
+    </main>
+    <footer></footer>
+  </body>
+</html>

--- a/src/js/ui/footer/index.js
+++ b/src/js/ui/footer/index.js
@@ -1,4 +1,4 @@
-import { handleActiveLinks } from "../../listeners/footer/handleActiveLinks";
+import { handleActiveLinks } from '../../listeners/footer/handleActiveLinks';
 
 /**
  * function that creates the footer, the function creates container elements aswell as div,list and anchor elements, the function also adds bootstrap classLists and content for the differet
@@ -90,7 +90,11 @@ export const footer = () => {
     '../../../../pages/footer/aboutNoroffJobs.html',
     'About Noroff Jobs'
   );
-  createListItem(forCompaniesList, '#', 'Company User Guide');
+  createListItem(
+    forCompaniesList,
+    '../../../../pages/footer/companyUserGuide.html',
+    'Company User Guide'
+  );
   createListItem(forCompaniesList, '../../../../pages/footer/faq.html', 'FAQ');
 
   const contactUsCol = createColumn(innerRow);

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,6 +22,7 @@ export default {
         user: path.resolve(__dirname, 'pages/user/index.html'),
         privacy: path.resolve(__dirname, 'privacy_policy.html'),
         terms: path.resolve(__dirname, 'terms_of_use.html'),
+        companyUserGuide: path.resolve(__dirname, 'pages/footer/companyUserGuide.html'),
       },
     },
   },


### PR DESCRIPTION
## Title
#1130 missing company user guide page

## Describe your changes: 
Made a Company User Guide page and a functional link directing users to the Company User Guide page when clicking "Company User Guide" in the footer. 

## Type of changes:
- Added a html file under "pages/footer/" called "companyUserGuide.html" were I copied the structure of "About Noroff Jobs"
- Updated the src/js/ui/footer/index.js file
- Updated the vite.config.js file

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
- No, issues encountered. The link works.

## Screenshots:
- Yes, the screenshots are included in the table below.

Before 
![before_screenshot](https://github.com/user-attachments/assets/a76383c9-685e-489e-82cb-258954604a9c) 

After
![after_screenshot](https://github.com/user-attachments/assets/1f90a467-b74a-4b44-842e-90d1cea57a47)

---------|--------
![cug_ss1](https://github.com/user-attachments/assets/8a64f7eb-d580-4649-b7cc-df8d3c6776aa)
![cug_ss2](https://github.com/user-attachments/assets/cf8bbf77-f6d9-4c2f-bdf5-20b9ddbbab45)
![src_js_ui_footer_index js_ss](https://github.com/user-attachments/assets/56faba1e-e5ec-4f74-bb2f-f1a5b5e35ee1)
![vite_config js_ss](https://github.com/user-attachments/assets/b04c348e-998d-4eba-a3eb-f5b9369f85c0)


## Additional information:
Reason for adding a company user guide page was that there wasn't any.

## Feedback
- Yes, I want feedback.
