### PR TITLE
Fix inconsistent sizing of listing images

### DIFF
--- a/pages/listings/index.html
+++ b/pages/listings/index.html
@@ -112,7 +112,7 @@
         <h4 class="visually-hidden">Subheading 1</h4>
         <div id="listingsErrorContainer" class="container"></div>
         <!--Bootstrap grid cards-->
-        <div class="row g-4 listingContainer justify-content-center px-5">
+        <div class="row g-4 listingContainer justify-content-center px-3">
           <!-- Listings -->
         </div>
       </div>

--- a/src/js/templates/listings/renderListing.js
+++ b/src/js/templates/listings/renderListing.js
@@ -60,13 +60,14 @@ const createListing = (result, userRole) => {
 };
 
 const createImg = ({ name, logo }) => {
+  const logoUrl = logo || 'https://shop.raceya.fit/wp-content/uploads/2020/11/logo-placeholder.jpg';
   const element = createElement(
     'img',
     ['listing-logo', 'my-5', 'card-img-top', 'rounded', 'w-75'],
     null,
     null,
     null,
-    logo,
+    logoUrl,
     name
   );
   return element;

--- a/src/js/templates/listings/renderListings.js
+++ b/src/js/templates/listings/renderListings.js
@@ -65,14 +65,13 @@ const createListings = ({ title, description, company, deadline, id }) => {
 const createImgContainer = ({ logo, name }) => {
   const element = createElement('div', [
     'm-0',
-    'p-3',
     'col-3',
     'd-flex',
     'flex-column',
     'justify-content-center',
   ]);
   const logoUrl = logo || 'https://shop.raceya.fit/wp-content/uploads/2020/11/logo-placeholder.jpg';
-  const img = createElement('img', ['img-fluid', 'rounded-start'], null, null, null, logoUrl, name);
+  const img = createElement('img', ['img-fluid', 'rounded-start', 'listings-logo'], null, null, null, logoUrl, name);
   element.append(img);
   return element;
 };

--- a/src/js/templates/listings/renderListings.js
+++ b/src/js/templates/listings/renderListings.js
@@ -71,7 +71,8 @@ const createImgContainer = ({ logo, name }) => {
     'flex-column',
     'justify-content-center',
   ]);
-  const img = createElement('img', ['img-fluid', 'rounded-start'], null, null, null, logo, name);
+  const logoUrl = logo || 'https://shop.raceya.fit/wp-content/uploads/2020/11/logo-placeholder.jpg';
+  const img = createElement('img', ['img-fluid', 'rounded-start'], null, null, null, logoUrl, name);
   element.append(img);
   return element;
 };

--- a/src/scss/custom/_singleListingPage.scss
+++ b/src/scss/custom/_singleListingPage.scss
@@ -5,3 +5,9 @@
   padding: 1rem;
   margin: 5rem auto;
 }
+
+.listings-logo {
+  min-width: 50px;
+  max-height: 100px;
+  object-fit: contain;
+}


### PR DESCRIPTION
## Ticket
https://github.com/orgs/NoroffFEU/projects/6/views/1?pane=issue&itemId=56662982&issue=NoroffFEU%7Cagency.noroff.dev%7C1103 - Listing Images Too Small and Inconsistent in Size

## Changes: 
Implemented a fallback default image if the logo field is empty. Made SCSS adjustments to ensure listing images are responsive and visible across all screen sizes.

## Type of changes:
* Added placeholder for listing images
* Adjusted padding under /pages/listings/
* Added new class (.listings-logo) in SCSS 

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [x] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
<!-- Remove the line below that you don't need -->
- Yes, I encountered issues. (Please describe below).
<!-- Description of the issues you run into -->
Currently, company logo images are not loading correctly for listings, causing all listings to display the fallback image. This update addresses the issue by ensuring the correct company logos are fetched and displayed when available, while maintaining the fallback behavior for missing logos.
## Screenshots:
<!-- Remove the line below that you don't need -->
- No screenshots to include.

## Feedback
<!-- Remove the line below that you don't need -->
- Yes, I want feedback.
