### PR TITLE
Fixed success message centering

### DIFF
--- a/src/scss/custom/profile/_profileCustomClasses.scss
+++ b/src/scss/custom/profile/_profileCustomClasses.scss
@@ -52,8 +52,6 @@ Version: 1.0.0
 }
 
 #success-modal {
-  width: 230px;
-  height: 230px;
   display: none;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Title
#1110 - Fixed success message modal size and centering

## Describe your changes: 

Using the developer tools i found that by deleting the Width and Height properties on the #success-modal it centered itself.
I checked the previous work done in this pull request "https://github.com/NoroffFEU/agency.noroff.dev/pull/1140" and saw that it it seemed to work when i inserted the code. But there seems to be some problems on smaller screenwidths that i didn't encounter when i just deleted code instead of adding. and ai didn't run into the problems described in the other pull request. Since seems to work best with the deletion this seemed like the best option, but if there are things i have overlooked please comment.



## Type of changes:
As stated earlier i deleted the width and height properties on #success-modal.

## Checklist before requesting a review

* [ ] I created a new branch before starting with this ticket?
* [ ] I commented the issue after finish in the Frontend Team Board?
* [ ] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
- No, issues encountered.

## Screenshots:

With code from previous code
![Screenshot 2025-05-29 175656](https://github.com/user-attachments/assets/383abf44-e265-4262-9785-55dbb1cc2eda)

With deletion of Width and Height properties

![Screenshot 2025-05-29 180252](https://github.com/user-attachments/assets/cecc57b4-4fcb-41b1-9cf4-21045c9d96dd)

| Before | After |



![Screenshot 2025-05-29 175132](https://github.com/user-attachments/assets/a143217b-b8e0-487b-b2a8-392a0299bcaa)|![Screenshot 2025-05-29 191031](https://github.com/user-attachments/assets/19567144-6682-478c-bf4a-22ca8d5e9ee8)


## Feedback
- Yes, I want feedback.
