### PR TITLE
1207 profile responsive listings

### DIFF
--- a/pages/user/index.html
+++ b/pages/user/index.html
@@ -107,9 +107,9 @@
           id="student-nav-tabContent">
           <div tabindex="0" class="tab-pane active" id="studentOffers" role="tabpanel">
             <!-- Student offers go here -->
-            <div class="row bg-theme-dark">
+            <div class="row bg-theme-dark gy-2 gx-2">
               <!-- Card 1 -->
-              <div class="col-12 col-lg-6 mb-3">
+              <div class="col-12 col-lg-6">
                 <div class="card rounded-0">
                   <div class="row g-0">
                     <div class="col-4 d-flex">
@@ -134,7 +134,7 @@
                 </div>
               </div>
               <!-- Card 2 -->
-              <div class="col-12 col-lg-6 mb-3">
+              <div class="col-12 col-lg-6">
                 <div class="card rounded-0">
                   <div class="row g-0">
                     <div class="col-4 d-flex">
@@ -159,7 +159,7 @@
                 </div>
               </div>
               <!-- Card 3 -->
-              <div class="col-12 col-lg-6 mb-3">
+              <div class="col-12 col-lg-6">
                 <div class="card rounded-0">
                   <div class="row g-0">
                     <div class="col-4 d-flex">
@@ -184,7 +184,7 @@
                 </div>
               </div>
               <!-- Card 4 -->
-              <div class="col-12 col-lg-6 mb-3">
+              <div class="col-12 col-lg-6">
                 <div class="card rounded-0">
                   <div class="row g-0">
                     <div class="col-4 d-flex">

--- a/pages/user/index.html
+++ b/pages/user/index.html
@@ -103,8 +103,7 @@
         </ul>
 
         <!-- Tab content -->
-        <div class="tab-content bg-theme-dark rounded-bottom rounded-end p-2 overflow-hidden"
-          id="student-nav-tabContent">
+        <div class="tab-content bg-theme-dark rounded-bottom rounded-end p-2" id="student-nav-tabContent">
           <div tabindex="0" class="tab-pane active" id="studentOffers" role="tabpanel">
             <!-- Student offers go here -->
             <div class="row bg-theme-dark gy-2 gx-2">

--- a/pages/user/index.html
+++ b/pages/user/index.html
@@ -47,14 +47,14 @@
       <i class="fa-solid fa-chevron-left"></i> Home
     </a>
 
-    <div class="container d-flex flex-column gap-4 bg-theme-light my-5 p-md-5 p-3 shadow maxWidthLayout">
+    <div class="container d-flex flex-column gap-4 bg-theme-light my-2 p-md-5 p-2 shadow maxWidthLayout">
       <!-- // Profile details goes here // -->
       <div class="container-sm" id="profileContainer">
         <div>
           <img class="rounded-circle d-block mx-auto w-25" id="profileImage"
             src="https://miniforetak.no/wp-content/plugins/buddyboss-platform/bp-core/images/profile-avatar-buddyboss.png"
             alt="Profile User Avatar" />
-          <h1 class="text-center mt-3 fw-bold" id="profileName"></h1>
+          <h1 class="text-center mt-3 fw-bold text-break" id="profileName"></h1>
           <p id="profileRole" class="text-center fw-bold fs-2"></p>
           <p id="profileContact" class="text-center fw-regular fs-1"></p>
           <p id="profileEmail" class="text-center fs-2 fw-lighter"></p>
@@ -103,7 +103,8 @@
         </ul>
 
         <!-- Tab content -->
-        <div class="tab-content bg-theme-dark rounded-bottom rounded-end p-5" id="student-nav-tabContent">
+        <div class="tab-content bg-theme-dark rounded-bottom rounded-end p-2 overflow-hidden"
+          id="student-nav-tabContent">
           <div tabindex="0" class="tab-pane active" id="studentOffers" role="tabpanel">
             <!-- Student offers go here -->
             <div class="row bg-theme-dark">


### PR DESCRIPTION
#1207 
On small devices (around 400px) the image and text for listings on the profile page overlaps.
To do: Check out the figma design, and make adjustments to the design. The white area should not be there, and the container with offers and applications should take up the space where the white area is now.

## Describe your changes: 
- changed paddings and margins
- added text-break

## Type of changes:
- bug fixes

## Checklist before requesting a review

* [x] I created a new branch before starting with this ticket?
* [x] I commented the issue after finish in the Frontend Team Board?
* [ ] I moved the card to Quality Assurance after finish?

## Did you run into any issues?
<!-- Remove the line below that you don't need -->
- No, issues encountered.


## Screenshots:

<img width="625" height="1120" alt="image" src="https://github.com/user-attachments/assets/0b063e4d-7e73-4be1-8545-833777bd0147" />


## Feedback

- Yes, I want feedback.
